### PR TITLE
Update Hello World README

### DIFF
--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,15 +1,36 @@
-# Hello World in ReasonML
+# Hello World
 
-First exercise in exercism's ReasonML track!
+The classical introductory exercise. Just say "Hello, World!".
 
-# Build + Watch
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
 
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+## Getting Started
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/reasonml).
+
+## Building and testing
+You will need the node package manager (npm) installed.
+There is one time setup for each exercise, which may take a few minutes:
 ```
-npm start
+npm install
 ```
 
-# Test + Watch
-
+Thereafter, to build:
 ```
-npm test
+npm run build
+```
+
+And to run the tests:
+```
+npm run test
 ```

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -19,18 +19,20 @@ For installation and learning resources, refer to the
 [exercism help page](http://exercism.io/languages/reasonml).
 
 ## Building and testing
-You will need the node package manager (npm) installed.
+You will need the node package manager (npm) installed - download from [here](https://www.npmjs.com/get-npm)
 There is one time setup for each exercise, which may take a few minutes:
 ```
 npm install
 ```
 
-Thereafter, to build:
+Open two shells, and in the first, start the build process.
 ```
-npm run build
+npm start
 ```
 
-And to run the tests:
+In the second, start the tests running.
 ```
-npm run test
+npm test
 ```
+
+As you edit the code, the two processes will continually rebuild and rerun the tests.


### PR DESCRIPTION
Updated hello world readme to include generic instructions from the ocaml repo.

Updated the npm run instructions... needed an npm install to get the tests to work for me. If I didn't run npm install, then npm test gave me:
Test suite failed to run

    Cannot find module 'bs-platform/lib/js/list.js' from 'jest.js'
      
      at Resolver.resolveModule (../../../node_modules/jest-resolve/build/index.js:169:17)
      at Object.<anonymous> (../../../node_modules/@glennsl/bs-jest/src/jest.js:3:12)

Is there a build & then test command? I have to build, test, stop the test watching, edit, rebuild, etc, which is a bit painful.