### PR TITLE
Tie dependent build tasks together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ cache:
     - node_modules
 
 script:
-  - bin/fetch-configlet
-  - bin/configlet lint --track-id reasonml .
-  - make copy-all-exercises
-  - npm run build
-  - npm run test:ci
+  - bin/fetch-configlet && bin/configlet lint --track-id reasonml .
+  - make copy-all-exercises && npm run build && npm run test:ci
   - make clean


### PR DESCRIPTION
So they fail together. When separate tasks, travis runs them all irrespective of failures and errors keep on cascading and becoming confusing for new contributors.

eg of cascading failure: https://travis-ci.org/exercism/reasonml/builds/403855347

Fix Ref: https://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step