### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -101,7 +101,7 @@
         "algorithms",
         "arrays",
         "folding",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -154,7 +154,6 @@
       "unlocked_by": "leap",
       "difficulty": 3,
       "topics": [
-        "arithmetic",
         "strings"
       ]
     },
@@ -222,9 +221,10 @@
       "difficulty": 2,
       "topics": [
         "algorithms",
+        "folding",
         "integers",
         "lists",
-        "folding"
+        "math"
       ]
     },
     {
@@ -235,8 +235,8 @@
       "difficulty": 2,
       "topics": [
         "algorithms",
-        "lists",
-        "folding"
+        "folding",
+        "lists"
       ]
     },
     {
@@ -246,9 +246,9 @@
       "unlocked_by": "bob",
       "difficulty": 4,
       "topics": [
-        "integers",
-        "bitwise_operations",
         "arrays",
+        "bitwise_operations",
+        "integers",
         "lists"
       ]
     },
@@ -259,9 +259,9 @@
       "unlocked_by": "rna-transcription",
       "difficulty": 4,
       "topics": [
-        "lists",
-        "hash-map-lookup",
-        "data-transform"
+        "data_transform",
+        "hash_map_lookup",
+        "lists"
       ]
     }
   ]


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110