### PR TITLE
Fix #56: jest error "localStorage is not available for opaque origins"

### DIFF
--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -5,8 +5,8 @@
     "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
-    "test": "jest --watchAll",
-    "test:ci": "jest --ci --bail --no-cache"
+    "test": "jest --watchAll --env=node",
+    "test:ci": "jest --ci --bail --no-cache --env=node"
   },
   "keywords": [
     "BuckleScript"


### PR DESCRIPTION
Add a `--env=node` flag to jest, all credits to @nickcernis, thanks!