### PR TITLE
Fix typo in bsconfig for space age. Should be 'spaceage', not 'leap'.

### DIFF
--- a/exercises/space-age/bsconfig.json
+++ b/exercises/space-age/bsconfig.json
@@ -1,7 +1,7 @@
 // This is the configuration file used by BuckleScript's build system bsb. Its documentation lives here: http://bucklescript.github.io/bucklescript/docson/#build-schema.json
 // BuckleScript comes with its own parser for bsconfig.json, which is normal JSON, with the extra support of comments and trailing commas.
 {
-  "name": "leap",
+  "name": "spaceage",
   "version": "0.1.0",
   "sources": [
     {


### PR DESCRIPTION
When I was starting the space age exercise, I did the following:

- `exercism download --exercise=space-age --track=reasonml`
- `npm install`
- `npm start`

and received this error: 

`SpaceAge-Leap.cmj not found, cmj format is generated by BuckleScript`

I thought the naming was off since Leap was the previous exercise and didn't have anything to do with space age. Eventually I noticed the bsconfig for space age was `leap` not `spaceage`

This change got me going again.