### PR TITLE
add simplified hello world source file

### DIFF
--- a/exercises/hello-world/src/HelloWorld.re
+++ b/exercises/hello-world/src/HelloWorld.re
@@ -1,0 +1,1 @@
+let hello = () => "Replace me!";


### PR DESCRIPTION
Howdy,

This PR simply adds the `HelloWorld.re` source file to simplify the introduction exercise to the point of simply replacing the string `Replace me!` with `Hello World!` to pass the tests. This will lower the barrier to entry in learning a new language, especially the initial hurdle of decyphering `bsb` errors due to the missing `.re` file. 

https://github.com/exercism/exercism/issues/4707

> We're starting to look at how to simplify the hello world landing page on the website, and one of the things that came out of that discussion, is the need to ensure that every single language track has the simplest possible "Hello, World!" exercise.

> We should define exactly what that means, but at first glance that would be:

> There is a stub solution that is missing only the string "Hello, World!"
> There is a test suite with exactly one test in it ("say hi"), that asserts the returned string
> The README correctly states to return the hard-coded string
