### PR TITLE
Update leap tests to v1.6.0

### DIFF
--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -13,9 +13,6 @@ on every year that is evenly divisible by 4
 For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
 year, but 2000 is.
 
-If your language provides a method in the standard library that does
-this look-up, pretend it doesn't exist and implement it yourself.
-
 ## Notes
 
 Though our exercise adopts some very simple rules, there is more to

--- a/exercises/leap/__tests__/Leap_test.re
+++ b/exercises/leap/__tests__/Leap_test.re
@@ -3,16 +3,31 @@ open Expect;
 open Leap;
 
 describe("Leap", () => {
-  test("year not divisible by 4: common year", () =>
+  test("year not divisible by 4 in common year", () =>
     expect(isLeapYear(2015)) |> toBe(false)
   );
-  test("year divisible by 4, not divisible by 100: leap year", () =>
+  test("year divisible by 2, not divisible by 4 in common year", () =>
+    expect(isLeapYear(1970)) |> toBe(false)
+  );
+  test("year divisible by 4, not divisible by 100 in leap year", () =>
     expect(isLeapYear(1996)) |> toBe(true)
   );
-  test("year divisible by 100, not divisible by 400: common year", () =>
+  test("year divisible by 4 and 5 is still a leap year", () =>
+    expect(isLeapYear(1960)) |> toBe(true)
+  );
+  test("year divisible by 100, not divisible by 400 in common year", () =>
     expect(isLeapYear(2100)) |> toBe(false)
   );
-  test("year divisible by 400: leap year", () =>
+  test("year divisible by 100 but not by 3 is still not a leap year", () =>
+    expect(isLeapYear(1900)) |> toBe(false)
+  );
+  test("year divisible by 400 in leap year", () =>
     expect(isLeapYear(2000)) |> toBe(true)
+  );
+  test("year divisible by 400 but not by 125 is still a leap year", () =>
+    expect(isLeapYear(2400)) |> toBe(true)
+  );
+  test("year divisible by 200, not divisible by 400 in common year", () =>
+    expect(isLeapYear(1800)) |> toBe(false)
   );
 })


### PR DESCRIPTION
1. Match canonical data v1.6.0 - multiple new tests added.
2. Minor README change - autogenerated from `bin/configlet generate .`