### PR TITLE
Update raindrops tests to v1.1.0

### DIFF
--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,24 +1,22 @@
 # Raindrops
 
-Convert a number to a string, the contents of which depend on the number's factors.
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
 
-- If the number has 3 as a factor, output 'Pling'.
-- If the number has 5 as a factor, output 'Plang'.
-- If the number has 7 as a factor, output 'Plong'.
-- If the number does not have 3, 5, or 7 as a factor,
-  just pass the number's digits straight through.
+The rules of `raindrops` are that if a given number:
+
+- has 3 as a factor, add 'Pling' to the result.
+- has 5 as a factor, add 'Plang' to the result.
+- has 7 as a factor, add 'Plong' to the result.
+- _does not_ have any of 3, 5, or 7 as a factor, the result should be the digits of the number.
 
 ## Examples
 
-- 28's factors are 1, 2, 4, **7**, 14, 28.
-  - In raindrop-speak, this would be a simple "Plong".
-- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
-  - In raindrop-speak, this would be a "PlingPlang".
-- 34 has four factors: 1, 2, 17, and 34.
-  - In raindrop-speak, this would be "34".
+- 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
+- 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
+- 34 is not factored by 3, 5, or 7, so the result would be "34".
 ## Source
 
-A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division. [https://en.wikipedia.org/wiki/Fizz_buzz](https://en.wikipedia.org/wiki/Fizz_buzz)
 
 ## Building and testing
 You will need the node package manager (npm) installed - download from [here](https://www.npmjs.com/get-npm)

--- a/exercises/raindrops/__tests__/Raindrops_test.re
+++ b/exercises/raindrops/__tests__/Raindrops_test.re
@@ -54,10 +54,10 @@ let () =
     test("the sound for 52 is 52", () =>
       expect(Raindrops.raindrops(52)) |> toEqual("52")
     );
-    test("the sound for 105 is PlingPlangPlong", () =>
+    test("the sound for 105 is PlingPlangPlong as it has factors of 3, 5 and 7", () =>
       expect(Raindrops.raindrops(105)) |> toEqual("PlingPlangPlong")
     );
-    test("the sound for 3125 is Plang", () =>
+    test("the sound for 3125 is Plang as it has factor 5", () =>
       expect(Raindrops.raindrops(3125)) |> toEqual("Plang")
     );
   });


### PR DESCRIPTION
1. Match canonical data `v1.1.0` - multiple new tests added.
2. Minor README changes - autogenerated from `bin/configlet generate .`