### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,0 +1,2 @@
+# exercise readme insert
+

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Reason](https://reasonml.github.io/) is a syntax and toolchain geared towards Javascript programmers, based on the functional language [OCaml](https://ocaml.org/)
 
 Being statically typed, it is likely to be safer than Javascript, but has powerful type inference which means type annotations do not get in your way.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 You will need the Node Package Manager (npm) to install Reason. Follow the instructions [here](https://www.npmjs.com/get-npm)
 
 Once you have npm, install Reason by:

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Reason for the first time. These resources can help you get started:
 
 [Reason home page](https://reasonml.github.io/)

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * [Reason home page](https://reasonml.github.io/)
 * [Reason Standard Library API](https://reasonml.github.io/api/index.html)
 * [Programmer blog](https://lucasmreis.github.io/blog/learning-reasonml-part-1/)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 npm is used to run the tests. Follow the instructions [here](https://www.npmjs.com/get-npm) to install npm.
 
 Once you have fetched an exercise with ```exercism fetch reasonml```


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
