### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -345,32 +345,32 @@
   "concepts": [],
   "key_features": [
     {
-      "icon": "features-ocaml-types",
+      "icon": "stable",
       "title": "OCaml's type system",
       "content": "ReScript brings OCaml's battle-tested powerful type system to Javascript."
     },
     {
-      "icon": "features-no-annotations",
+      "icon": "immutable",
       "title": "Inferred types",
       "content": "No need to specify types, types are inferred by ReScript compiler and are guaranteed to be correct."
     },
     {
-      "icon": "features-functional",
+      "icon": "functional",
       "title": "Functional Programming",
       "content": "Like OCaml, ReScript is a functional programming language with pattern matching, variants and more."
     },
     {
-      "icon": "features-js-interop",
+      "icon": "interop",
       "title": "Easy javascript interop",
       "content": "Javascript interop is easy allowing advatange of existing javascript packages and ecosystem."
     },
     {
-      "icon": "features-fast-compiler",
+      "icon": "fast",
       "title": "Fast compiler",
       "content": "ReScript compilation times are super fast which means fast iteration cycles."
     },
     {
-      "icon": "features-refactoring-ease",
+      "icon": "fun",
       "title": "Refactor with ease",
       "content": "Compiler guides you through all places that need to be fixed during refactor until it just works."
     }


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![stable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/stable.svg) OCaml's type system
ReScript brings OCaml's battle-tested powerful type system to Javascript.

![immutable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/immutable.svg) Inferred types
No need to specify types, types are inferred by ReScript compiler and are guaranteed to be correct.

![functional](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/functional.svg) Functional Programming
Like OCaml, ReScript is a functional programming language with pattern matching, variants and more.

![interop](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interop.svg) Easy javascript interop
Javascript interop is easy allowing advatange of existing javascript packages and ecosystem.

![fast](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fast.svg) Fast compiler
ReScript compilation times are super fast which means fast iteration cycles.

![fun](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fun.svg) Refactor with ease
Compiler guides you through all places that need to be fixed during refactor until it just works.
