### PR TITLE
Sync `roman-numeral` tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -30,6 +30,9 @@ description = "6 is VI"
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9 is IX"
 
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "27 is XXVII"
 
@@ -42,6 +45,9 @@ description = "49 is XLIX"
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "59 is LIX"
 
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "93 is XCIII"
 
@@ -51,11 +57,17 @@ description = "141 is CXLI"
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "163 is CLXIII"
 
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "575 is DLXXV"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "911 is CMXI"
@@ -63,5 +75,17 @@ description = "911 is CMXI"
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1024 is MXXIV"
 
+[efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
+description = "1666 is MDCLXVI"
+
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
 description = "3000 is MMM"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/__tests__/RomanNumerals_test.re
+++ b/exercises/practice/roman-numerals/__tests__/RomanNumerals_test.re
@@ -3,62 +3,86 @@ open Expect;
 open RomanNumerals;
 
 describe("RomanNumerals", () => {
-  test("1 is a single I", () =>
+  test("1 is I", () =>
     expect(toRoman(1)) |> toEqual("I")
   );
-  test("2 is two I's", () =>
+  test("2 is II", () =>
     expect(toRoman(2)) |> toEqual("II") 
   );
-  test("3 is three I's", () =>
+  test("3 is III", () =>
     expect(toRoman(3)) |> toEqual("III") 
   );
-  test("4, being 5 - 1, is IV", () =>
+  test("4 is IV", () =>
     expect(toRoman(4)) |> toEqual("IV")
   );
-  test("5 is a single V", () =>
+  test("5 is V", () =>
     expect(toRoman(5)) |> toEqual("V") 
   );
-  test("6, being 5 + 1, is VI", () =>
+  test("6 is VI", () =>
     expect(toRoman(6)) |> toEqual("VI") 
   );
-  test("9, being 10 - 1, is IX", () =>
+  test("9 is IX", () =>
     expect(toRoman(9)) |> toEqual("IX") 
   );
-  test("20 is two X's", () =>
+  test("16 is XVI", () =>
+    expect(toRoman(16)) |> toEqual("XVI") 
+  );
+  test("27 is XXVII", () =>
     expect(toRoman(27)) |> toEqual("XXVII")
   );
-  test("48 is not 50 - 2 but rather 40 + 8", () =>
+  test("48 is XLVIII", () =>
     expect(toRoman(48)) |> toEqual("XLVIII") 
   );
-  test("49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1", () =>
+  test("49 is XLIX", () =>
     expect(toRoman(49)) |> toEqual("XLIX") 
   );
-  test("50 is a single L", () =>
+  test("59 is LIX", () =>
     expect(toRoman(59)) |> toEqual("LIX") 
   );
-  test("90, being 100 - 10, is XC", () =>
+  test("66 is LXVI", () =>
+    expect(toRoman(66)) |> toEqual("LXVI") 
+  );
+  test("93 is XCIII", () =>
     expect(toRoman(93)) |> toEqual("XCIII") 
   );
-  test("100 is a single C", () =>
+  test("141 is CXLI", () =>
     expect(toRoman(141)) |> toEqual("CXLI") 
   );
-  test("60, being 50 + 10, is LX", () =>
+  test("163 is CLXIII", () =>
     expect(toRoman(163)) |> toEqual("CLXIII") 
   );
-  test("400, being 500 - 100, is CD", () =>
+  test("166 is CLXVI", () =>
+    expect(toRoman(166)) |> toEqual("CLXVI") 
+  );
+  test("402 is CDII", () =>
     expect(toRoman(402)) |> toEqual("CDII") 
   );
-  test("500 is a single D", () =>
+  test("575 is DLXXV", () =>
     expect(toRoman(575)) |> toEqual("DLXXV") 
   );
-  test("900, being 1000 - 100, is CM", () =>
+  test("666 is DCLXVI", () =>
+    expect(toRoman(666)) |> toEqual("DCLXVI") 
+  );
+  test("911 is CMXI", () =>
     expect(toRoman(911)) |> toEqual("CMXI")
   );
-  test("1000 is a single M", () =>
+  test("1024 is MXXIV", () =>
     expect(toRoman(1024)) |> toEqual("MXXIV")
   );
-  test("3000 is three M's", () =>
+  test("1666 is MDCLXVI", () =>
+    expect(toRoman(1666)) |> toEqual("MDCLXVI")
+  );
+  test("3000 is MMM", () =>
     expect(toRoman(3000)) |> toEqual("MMM")
+  );
+  test("3001 is MMMI", () =>
+    expect(toRoman(3001)) |> toEqual("MMMI")
+  );
+  test("3888 is MMMDCCCLXXXVIII", () =>
+    expect(toRoman(3888)) |> toEqual("MMMDCCCLXXXVIII")
+  );
+  test("3999 is MMMCMXCIX", () =>
+    expect(toRoman(3999)) |> toEqual("MMMCMXCIX")
   );
 });
 


### PR DESCRIPTION
Several tests had correct test cases but incorrect descriptions. Another eight tests were added from upstream